### PR TITLE
Check for sortedness must not use `==`

### DIFF
--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1424,7 +1424,7 @@ if (Rs.length >= 2 &&
     assert(m.empty);
 }
 
-// test sortedness with predicate `less` that contradicts `==`
+// Issue 21810: Check for sortedness must not use `==`
 @nogc @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1428,28 +1428,29 @@ if (Rs.length >= 2 &&
 @nogc @safe pure nothrow unittest
 {
     import std.algorithm.comparison : equal;
+    import std.typecons : tuple;
 
     static immutable a = [
-        [1, 1],
-        [3, 1],
-        [3, 2],
-        [5, 1],
+        tuple(1, 1),
+        tuple(3, 1),
+        tuple(3, 2),
+        tuple(5, 1),
     ];
     static immutable b = [
-        [2, 1],
-        [3, 1],
-        [4, 1],
-        [4, 2],
+        tuple(2, 1),
+        tuple(3, 1),
+        tuple(4, 1),
+        tuple(4, 2),
     ];
     static immutable r = [
-        [1, 1],
-        [2, 1],
-        [3, 1],
-        [3, 2],
-        [3, 1],
-        [4, 1],
-        [4, 2],
-        [5, 1],
+        tuple(1, 1),
+        tuple(2, 1),
+        tuple(3, 1),
+        tuple(3, 2),
+        tuple(3, 1),
+        tuple(4, 1),
+        tuple(4, 2),
+        tuple(5, 1),
     ];
     assert(merge!"a[0] < b[0]"(a, b).equal(r));
 }

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1424,6 +1424,36 @@ if (Rs.length >= 2 &&
     assert(m.empty);
 }
 
+// test sortedness with predicate `less` that contradicts `==`
+@nogc @safe pure nothrow unittest
+{
+    import std.algorithm.comparison : equal;
+
+    static immutable a = [
+        [1, 1],
+        [3, 1],
+        [3, 2],
+        [5, 1],
+    ];
+    static immutable b = [
+        [2, 1],
+        [3, 1],
+        [4, 1],
+        [4, 2],
+    ];
+    static immutable r = [
+        [1, 1],
+        [2, 1],
+        [3, 1],
+        [3, 2],
+        [3, 1],
+        [4, 1],
+        [4, 2],
+        [5, 1],
+    ];
+    assert(merge!"a[0] < b[0]"(a, b).equal(r));
+}
+
 private template validPredicates(E, less...)
 {
     static if (less.length == 0)

--- a/std/algorithm/sorting.d
+++ b/std/algorithm/sorting.d
@@ -1157,8 +1157,7 @@ if (Rs.length >= 2 &&
                 {
                     if (!source[i].empty)
                     {
-                        assert(previousFront == source[i].front ||
-                               comp(previousFront, source[i].front),
+                        assert(!comp(source[i].front, previousFront),
                                "Input " ~ i.stringof ~ " is unsorted"); // @nogc
                     }
                 }
@@ -1224,8 +1223,7 @@ if (Rs.length >= 2 &&
                     {
                         if (!source[i].empty)
                         {
-                            assert(previousBack == source[i].back ||
-                                   comp(source[i].back, previousBack),
+                            assert(!comp(previousBack, source[i].back),
                                    "Input " ~ i.stringof ~ " is unsorted"); // @nogc
                         }
                     }


### PR DESCRIPTION
Checking sortedness according to a given predicate must not use `==` operator
because it may not be in accordance with the predicate.